### PR TITLE
Updating Run Jar command in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,4 +47,8 @@ docker run -it --rm -v $(pwd):/code --workdir /code maven mvn clean test -e
 docker run -it --rm -v $(pwd):/code --workdir /code maven mvn clean package -e
 
 ### Run Jar
-docker run -it --rm -p 8082:8081  -v $(pwd):/code --workdir /code maven ./mvnw spring-boot:run
+docker run -it --rm -p 8081:8081  -v $(pwd):/code --workdir /code maven java -jar build/DevOpsUsach2020-0.0.1.jar
+
+### Repeat the full process
+docker run -it --rm -p 8081:8081  -v $(pwd):/code --workdir /code maven mvn spring-boot:run
+


### PR DESCRIPTION
Hola profe!

Agregamos el código para ejecutar solamente el compilado que se generó

Y además hicimos los ajustes en el código de ejecución anterior, apuntando hacia el puerto 8081, ejecutando directamente desde `mvn` e indicando en el comentario que este comando ejecuta el proceso completo.

Todo feedback es bienvenido, saludos!